### PR TITLE
Implement realtime recent activity on admin dashboard

### DIFF
--- a/backend/PostApet/PostApet/src/main/java/com/example/PostApet/Controller/PetController.java
+++ b/backend/PostApet/PostApet/src/main/java/com/example/PostApet/Controller/PetController.java
@@ -112,6 +112,12 @@ public class PetController {
         return petService.getAllPets();
     }
 
+    @GetMapping("/recent")
+    public ResponseEntity<List<PetDto>> getRecentPets(@RequestParam(defaultValue = "5") int limit) {
+        List<PetDto> pets = petService.getRecentPets(limit);
+        return ResponseEntity.ok(pets);
+    }
+
     @GetMapping("/get/{id}")
     public ResponseEntity<PetDto> getPetById(@PathVariable Long id) {
         PetDto pet = petService.getPetById(id);

--- a/backend/PostApet/PostApet/src/main/java/com/example/PostApet/Service/PetService.java
+++ b/backend/PostApet/PostApet/src/main/java/com/example/PostApet/Service/PetService.java
@@ -8,6 +8,8 @@ import com.example.PostApet.dto.PetDto;
 import com.example.PostApet.dto.QuizRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -95,6 +97,15 @@ public abstract class PetService {
 
     public List<PetDto> getRecentApprovedPets(int limit) {
         return petRepository.findTop8ByRegStatusOrderByIdDesc("Approved")
+                .stream()
+                .map(PetDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    public List<PetDto> getRecentPets(int limit) {
+        PageRequest request = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "id"));
+        return petRepository.findAll(request)
+                .getContent()
                 .stream()
                 .map(PetDto::fromEntity)
                 .collect(Collectors.toList());


### PR DESCRIPTION
## Summary
- expose new `/pets/recent` API endpoint to fetch newest pets
- add service method to query recent pets ordered by id
- update admin dashboard to poll `/pets/recent` every 10s

## Testing
- `./mvnw test` *(fails: repo.maven.apache.org blocked)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68641225bc5483229073b7ecbf274878