### PR TITLE
Add user analytics metrics

### DIFF
--- a/backend/PostApet/PostApet/src/main/java/com/example/PostApet/Controller/UserMetricsController.java
+++ b/backend/PostApet/PostApet/src/main/java/com/example/PostApet/Controller/UserMetricsController.java
@@ -1,0 +1,29 @@
+package com.example.PostApet.Controller;
+
+import com.example.PostApet.Service.jwt.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/admin/metrics")
+@CrossOrigin(origins = "http://localhost:3000")
+public class UserMetricsController {
+
+    private final UserService userService;
+
+    @Autowired
+    public UserMetricsController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/users")
+    public ResponseEntity<Map<String, Long>> getUserMetrics() {
+        return ResponseEntity.ok(userService.getUserRoleCounts());
+    }
+}

--- a/backend/PostApet/PostApet/src/main/java/com/example/PostApet/Service/jwt/UserService.java
+++ b/backend/PostApet/PostApet/src/main/java/com/example/PostApet/Service/jwt/UserService.java
@@ -16,6 +16,9 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import com.example.PostApet.Enum.UserRole;
 
 @Service
 public class UserService implements UserDetailsService {
@@ -101,6 +104,17 @@ public class UserService implements UserDetailsService {
 
     public List<User> getAllUsers() {
         return userRepository.findAll();
+    }
+
+    public Map<String, Long> getUserRoleCounts() {
+        long adminCount = userRepository.findAllByUserRole(UserRole.ADMIN).size();
+        long userCount = userRepository.findAllByUserRole(UserRole.USER).size();
+
+        Map<String, Long> counts = new HashMap<>();
+        counts.put("adminCount", adminCount);
+        counts.put("userCount", userCount);
+        counts.put("totalUsers", adminCount + userCount);
+        return counts;
     }
 
 }

--- a/frontend/src/adminPanel/Dashboard/AdminDashboard.js
+++ b/frontend/src/adminPanel/Dashboard/AdminDashboard.js
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { FaPaw, FaCheckCircle, FaTimesCircle, FaChartBar } from 'react-icons/fa';
+import { FaPaw, FaCheckCircle, FaTimesCircle, FaChartBar, FaUser } from 'react-icons/fa';
 import axiosInstance from '../../api/axiosConfig';
 import BarChartComponent from './BarChart';
 import PieChartComponent from './PieChart';
+import UserPieChart from './UserPieChart';
 import './AdminDashboard.css';
 
 const AdminDashboard = () => {
@@ -11,6 +12,11 @@ const AdminDashboard = () => {
     pendingRequests: 0,
     approvedRequests: 0,
     rejectedRequests: 0
+  });
+  const [userMetrics, setUserMetrics] = useState({
+    adminCount: 0,
+    userCount: 0,
+    totalUsers: 0
   });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -24,8 +30,12 @@ const AdminDashboard = () => {
     try {
       setLoading(true);
       
-      const petsResponse = await axiosInstance.get("/pets/getAll");
+      const [petsResponse, userMetricRes] = await Promise.all([
+        axiosInstance.get("/pets/getAll"),
+        axiosInstance.get("/admin/metrics/users")
+      ]);
       const pets = petsResponse.data;
+      const userData = userMetricRes.data;
       
       const totalPets = pets.length;
       const approvedRequests = pets.filter(pet => pet.regStatus === "Approved").length;
@@ -38,6 +48,7 @@ const AdminDashboard = () => {
         approvedRequests,
         rejectedRequests
       });
+      setUserMetrics(userData);
       
       setError(null);
     } catch (error) {
@@ -122,6 +133,12 @@ const AdminDashboard = () => {
           value={dashboardData.rejectedRequests}
           color="danger"
         />
+        <StatCard
+          icon={<FaUser className="admin-stat-icon-svg" />}
+          title="Total Users"
+          value={userMetrics.totalUsers}
+          color="primary"
+        />
       </div>
 
       {/* Main Content Area */}
@@ -142,10 +159,16 @@ const AdminDashboard = () => {
                 />
               </div>
               <div className="admin-mini-chart">
-                <BarChartComponent 
-                  data={dashboardData} 
+                <BarChartComponent
+                  data={dashboardData}
                   title={null}
                   miniView={true}
+                />
+              </div>
+              <div className="admin-mini-chart">
+                <UserPieChart
+                  data={userMetrics}
+                  title={"User Roles"}
                 />
               </div>
             </div>

--- a/frontend/src/adminPanel/Dashboard/UserPieChart.js
+++ b/frontend/src/adminPanel/Dashboard/UserPieChart.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
+import './PieChart.css';
+
+const UserPieChart = ({ data, title }) => {
+  const chartData = [
+    { name: 'Admins', value: data.adminCount || 0, color: '#007bff' },
+    { name: 'Users', value: data.userCount || 0, color: '#28a745' }
+  ].filter(item => item.value > 0);
+
+  if (chartData.length === 0) {
+    return (
+      <div className="chart-container">
+        <div className="chart-header">
+          <h3>{title || 'User Roles'}</h3>
+        </div>
+        <div className="no-data">
+          <p>No data available for pie chart</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="chart-container">
+      <div className="chart-header">
+        <h3>{title || 'User Roles'}</h3>
+      </div>
+      <div className="pie-chart-wrapper">
+        <ResponsiveContainer width="100%" height={300}>
+          <PieChart>
+            <Pie data={chartData} cx="50%" cy="50%" labelLine={false} outerRadius={120} dataKey="value">
+              {chartData.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={entry.color} />
+              ))}
+            </Pie>
+            <Tooltip />
+            <Legend />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};
+
+export default UserPieChart;


### PR DESCRIPTION
## Summary
- add backend endpoint to expose user role counts
- extend UserService with `getUserRoleCounts`
- display user metrics in admin dashboard
- add new `UserPieChart` chart component

## Testing
- `npx eslint frontend/src/adminPanel/Dashboard/AdminDashboard.js`
- `mvn -q test` *(fails: command not found)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68641b5494d483229590cfcb86b12e85