### PR TITLE
Add user stats charts to admin dashboard

### DIFF
--- a/backend/PostApet/PostApet/src/main/java/com/example/PostApet/Controller/AdminStatsController.java
+++ b/backend/PostApet/PostApet/src/main/java/com/example/PostApet/Controller/AdminStatsController.java
@@ -1,0 +1,26 @@
+package com.example.PostApet.Controller;
+
+import com.example.PostApet.Service.UserStatsService;
+import com.example.PostApet.dto.UserStatsDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/admin/stats")
+@CrossOrigin(origins = "http://localhost:3000")
+public class AdminStatsController {
+    private final UserStatsService userStatsService;
+
+    @Autowired
+    public AdminStatsController(UserStatsService userStatsService) {
+        this.userStatsService = userStatsService;
+    }
+
+    @GetMapping("/users")
+    @PreAuthorize("hasAuthority('ADMIN')")
+    public ResponseEntity<UserStatsDto> getUserStats() {
+        return ResponseEntity.ok(userStatsService.getUserStats());
+    }
+}

--- a/backend/PostApet/PostApet/src/main/java/com/example/PostApet/Repository/UserRepository.java
+++ b/backend/PostApet/PostApet/src/main/java/com/example/PostApet/Repository/UserRepository.java
@@ -15,4 +15,6 @@ public interface UserRepository extends JpaRepository<User,Long> {
     Optional<User> findFirstByEmail(String email);
 
     List<User> findAllByUserRole(UserRole userRole);
+
+    long countByUserRole(UserRole userRole);
 }

--- a/backend/PostApet/PostApet/src/main/java/com/example/PostApet/Service/UserStatsService.java
+++ b/backend/PostApet/PostApet/src/main/java/com/example/PostApet/Service/UserStatsService.java
@@ -1,0 +1,25 @@
+package com.example.PostApet.Service;
+
+import com.example.PostApet.Enum.UserRole;
+import com.example.PostApet.Repository.UserRepository;
+import com.example.PostApet.dto.UserStatsDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserStatsService {
+    private final UserRepository userRepository;
+
+    @Autowired
+    public UserStatsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public UserStatsDto getUserStats() {
+        UserStatsDto dto = new UserStatsDto();
+        dto.setTotalUsers(userRepository.count());
+        dto.setAdminCount(userRepository.countByUserRole(UserRole.ADMIN));
+        dto.setUserCount(userRepository.countByUserRole(UserRole.USER));
+        return dto;
+    }
+}

--- a/backend/PostApet/PostApet/src/main/java/com/example/PostApet/dto/UserStatsDto.java
+++ b/backend/PostApet/PostApet/src/main/java/com/example/PostApet/dto/UserStatsDto.java
@@ -1,0 +1,31 @@
+package com.example.PostApet.dto;
+
+public class UserStatsDto {
+    private long totalUsers;
+    private long adminCount;
+    private long userCount;
+
+    public long getTotalUsers() {
+        return totalUsers;
+    }
+
+    public void setTotalUsers(long totalUsers) {
+        this.totalUsers = totalUsers;
+    }
+
+    public long getAdminCount() {
+        return adminCount;
+    }
+
+    public void setAdminCount(long adminCount) {
+        this.adminCount = adminCount;
+    }
+
+    public long getUserCount() {
+        return userCount;
+    }
+
+    public void setUserCount(long userCount) {
+        this.userCount = userCount;
+    }
+}

--- a/frontend/src/adminPanel/Dashboard/AdminDashboard.css
+++ b/frontend/src/adminPanel/Dashboard/AdminDashboard.css
@@ -29,7 +29,7 @@
 /* Stats Grid */
 .admin-stats-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 20px;
   margin-bottom: 25px;
 }

--- a/frontend/src/adminPanel/Dashboard/AdminDashboard.js
+++ b/frontend/src/adminPanel/Dashboard/AdminDashboard.js
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { FaPaw, FaCheckCircle, FaTimesCircle, FaChartBar } from 'react-icons/fa';
+import { FaPaw, FaCheckCircle, FaTimesCircle, FaChartBar, FaUsers } from 'react-icons/fa';
 import axiosInstance from '../../api/axiosConfig';
 import BarChartComponent from './BarChart';
 import PieChartComponent from './PieChart';
+import UserRolePieChart from './UserRolePieChart';
 import './AdminDashboard.css';
 
 const AdminDashboard = () => {
@@ -10,7 +11,10 @@ const AdminDashboard = () => {
     totalPets: 0,
     pendingRequests: 0,
     approvedRequests: 0,
-    rejectedRequests: 0
+    rejectedRequests: 0,
+    totalUsers: 0,
+    adminCount: 0,
+    userCount: 0
   });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -23,20 +27,28 @@ const AdminDashboard = () => {
   const fetchDashboardData = async () => {
     try {
       setLoading(true);
-      
-      const petsResponse = await axiosInstance.get("/pets/getAll");
+
+      const [petsResponse, userStatsResponse] = await Promise.all([
+        axiosInstance.get("/pets/getAll"),
+        axiosInstance.get("/admin/stats/users")
+      ]);
+
       const pets = petsResponse.data;
-      
+      const userStats = userStatsResponse.data;
+
       const totalPets = pets.length;
       const approvedRequests = pets.filter(pet => pet.regStatus === "Approved").length;
       const rejectedRequests = pets.filter(pet => pet.regStatus === "Rejected").length;
       const pendingRequests = pets.filter(pet => !pet.regStatus || pet.regStatus === "Pending").length;
-      
+
       setDashboardData({
         totalPets,
         pendingRequests,
         approvedRequests,
-        rejectedRequests
+        rejectedRequests,
+        totalUsers: userStats.totalUsers,
+        adminCount: userStats.adminCount,
+        userCount: userStats.userCount
       });
       
       setError(null);
@@ -122,6 +134,12 @@ const AdminDashboard = () => {
           value={dashboardData.rejectedRequests}
           color="danger"
         />
+        <StatCard
+          icon={<FaUsers className="admin-stat-icon-svg" />}
+          title="Total Users"
+          value={dashboardData.totalUsers}
+          color="primary"
+        />
       </div>
 
       {/* Main Content Area */}
@@ -151,7 +169,18 @@ const AdminDashboard = () => {
             </div>
           </div>
 
-         
+          {/* User Role Distribution */}
+          <div className="admin-analytics-mini">
+            <h2 className="admin-section-title">
+              <FaChartBar className="admin-section-icon" /> User Roles
+            </h2>
+            <div className="admin-mini-charts">
+              <div className="admin-mini-chart">
+                <UserRolePieChart data={dashboardData} />
+              </div>
+            </div>
+          </div>
+
         </div>
 
         {/* Right Column */}

--- a/frontend/src/adminPanel/Dashboard/UserRolePieChart.js
+++ b/frontend/src/adminPanel/Dashboard/UserRolePieChart.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+const UserRolePieChart = ({ data }) => {
+  const chartData = [
+    { name: 'Admins', value: data.adminCount || 0, color: '#916ed6' },
+    { name: 'Users', value: data.userCount || 0, color: '#28a745' }
+  ].filter(item => item.value > 0);
+
+  if (chartData.length === 0) {
+    return <p>No user data available</p>;
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <PieChart>
+        <Pie data={chartData} dataKey="value" cx="50%" cy="50%" outerRadius={100} label>
+          {chartData.map((entry, index) => (
+            <Cell key={`cell-${index}`} fill={entry.color} />
+          ))}
+        </Pie>
+        <Tooltip />
+        <Legend />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+};
+
+export default UserRolePieChart;


### PR DESCRIPTION
## Summary
- add backend user stats endpoint and service
- expose `/api/v1/admin/stats/users`
- include new UserRolePieChart component
- display user stats on the admin dashboard
- update stats grid layout

## Testing
- `mvn -q test` *(fails: mvn not found)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68641dc9e64083228dcc34612e08a2aa