### PR TITLE
Add user role analytics chart

### DIFF
--- a/frontend/src/adminPanel/Dashboard/AdminDashboard.js
+++ b/frontend/src/adminPanel/Dashboard/AdminDashboard.js
@@ -3,6 +3,7 @@ import { FaPaw, FaCheckCircle, FaTimesCircle, FaChartBar } from 'react-icons/fa'
 import axiosInstance from '../../api/axiosConfig';
 import BarChartComponent from './BarChart';
 import PieChartComponent from './PieChart';
+import UserRoleBarChart from './UserRoleBarChart';
 import './AdminDashboard.css';
 
 const AdminDashboard = () => {
@@ -11,6 +12,11 @@ const AdminDashboard = () => {
     pendingRequests: 0,
     approvedRequests: 0,
     rejectedRequests: 0
+  });
+  const [userStats, setUserStats] = useState({
+    totalUsers: 0,
+    adminCount: 0,
+    userCount: 0
   });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -25,7 +31,10 @@ const AdminDashboard = () => {
       setLoading(true);
       
       const petsResponse = await axiosInstance.get("/pets/getAll");
+      const usersResponse = await axiosInstance.get("/auth/users");
+
       const pets = petsResponse.data;
+      const users = usersResponse.data || [];
       
       const totalPets = pets.length;
       const approvedRequests = pets.filter(pet => pet.regStatus === "Approved").length;
@@ -38,6 +47,12 @@ const AdminDashboard = () => {
         approvedRequests,
         rejectedRequests
       });
+
+      const totalUsers = users.length;
+      const adminCount = users.filter(u => u.userRole === 'ADMIN').length;
+      const userCount = users.filter(u => u.userRole === 'USER').length;
+
+      setUserStats({ totalUsers, adminCount, userCount });
       
       setError(null);
     } catch (error) {
@@ -151,7 +166,21 @@ const AdminDashboard = () => {
             </div>
           </div>
 
-         
+          <div className="admin-analytics-mini">
+            <h2 className="admin-section-title">
+              <FaChartBar className="admin-section-icon" /> User Roles
+            </h2>
+            <div className="admin-mini-charts">
+              <div className="admin-mini-chart">
+                <UserRoleBarChart
+                  data={userStats}
+                  title={null}
+                />
+              </div>
+            </div>
+          </div>
+
+
         </div>
 
         {/* Right Column */}

--- a/frontend/src/adminPanel/Dashboard/UserRoleBarChart.js
+++ b/frontend/src/adminPanel/Dashboard/UserRoleBarChart.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+const UserRoleBarChart = ({ data, title }) => {
+  const chartData = [
+    { name: 'Admins', count: data.adminCount || 0, fill: '#916ed6' },
+    { name: 'Users', count: data.userCount || 0, fill: '#28a745' }
+  ];
+
+  const CustomTooltip = ({ active, payload, label }) => {
+    if (active && payload && payload.length) {
+      return (
+        <div className="custom-tooltip">
+          <p className="tooltip-label">{`${label}: ${payload[0].value}`}</p>
+          <p className="tooltip-desc">
+            {`${((payload[0].value / data.totalUsers) * 100).toFixed(1)}% of users`}
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <div className="chart-container">
+      <div className="chart-header">
+        <h3>{title || 'User Role Distribution'}</h3>
+        <p className="chart-subtitle">Breakdown of users by role</p>
+      </div>
+      <div className="chart-wrapper">
+        <ResponsiveContainer width="100%" height={300}>
+          <BarChart data={chartData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
+            <XAxis dataKey="name" tick={{ fontSize: 12 }} axisLine={{ stroke: '#666' }} />
+            <YAxis tick={{ fontSize: 12 }} axisLine={{ stroke: '#666' }} />
+            <Tooltip content={<CustomTooltip />} />
+            <Legend wrapperStyle={{ fontSize: '12px', paddingTop: '20px' }} />
+            <Bar dataKey="count" radius={[4,4,0,0]} stroke="#fff" strokeWidth={1} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};
+
+export default UserRoleBarChart;


### PR DESCRIPTION
## Summary
- add new `UserRoleBarChart` component to visualize admin/user counts
- fetch user data in admin dashboard and display new chart

## Testing
- `npm test` *(fails: react-scripts not found)*
- `./mvnw -q test` *(fails: network blocked for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6864220201e48322b609fb6bf4220d24