### PR TITLE
Configure email via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Haven Project
+
+This repository contains a Spring Boot backend and a React frontend.
+
+## Email Notifications
+
+The backend uses Spring Mail to send notification emails when:
+
+- A user updates profile details.
+- A user changes their password.
+- A new adoption post is created.
+- An adoption post is approved.
+
+To enable email sending, configure the following environment variables before running the backend:
+
+```
+MAIL_HOST     # e.g. smtp.gmail.com
+MAIL_PORT     # e.g. 587
+MAIL_USERNAME # your SMTP username
+MAIL_PASSWORD # your SMTP password or app password
+```
+
+If no variables are provided, the backend defaults to Gmail's SMTP host and port.

--- a/backend/PostApet/PostApet/src/main/resources/application.properties
+++ b/backend/PostApet/PostApet/src/main/resources/application.properties
@@ -34,10 +34,10 @@ limitRefreshPeriod: 60s
 timeoutDuration: 5s
 
 # Mail configuration
-spring.mail.host=smtp.example.com
-spring.mail.port=587
-spring.mail.username=chamodi0819@gmail.com
-spring.mail.password=vswd ywdw bmhv infu
+spring.mail.host=${MAIL_HOST:smtp.gmail.com}
+spring.mail.port=${MAIL_PORT:587}
+spring.mail.username=${MAIL_USERNAME}
+spring.mail.password=${MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 


### PR DESCRIPTION
## Summary
- make mail configuration use environment variables
- document how to configure email

## Testing
- `./mvnw -q test` *(fails: network access needed to download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6870f0d32a648322810e0067fe2b1fbc