### PR TITLE
Implement admin user deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The backend uses Spring Mail to send notification emails when:
 - A user updates profile details.
 - A user changes their password.
 - A user deletes their profile.
+- An admin deletes a user profile.
 - A new adoption post is created.
 - An adoption post is approved or rejected.
 

--- a/backend/PostApet/PostApet/src/main/java/com/example/PostApet/Controller/auth/AuthController.java
+++ b/backend/PostApet/PostApet/src/main/java/com/example/PostApet/Controller/auth/AuthController.java
@@ -126,5 +126,18 @@ public class AuthController {
         }
     }
 
+    /**
+     * Delete a user by ID. Intended for administrative use.
+     */
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<?> deleteUser(@PathVariable Long userId) {
+        try {
+            userService.deleteUserById(userId);
+            return ResponseEntity.ok().build();
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
 
 }

--- a/backend/PostApet/PostApet/src/main/java/com/example/PostApet/Service/jwt/UserService.java
+++ b/backend/PostApet/PostApet/src/main/java/com/example/PostApet/Service/jwt/UserService.java
@@ -118,6 +118,22 @@ public class UserService implements UserDetailsService {
         return userRepository.findAll();
     }
 
+    /**
+     * Delete a user profile by ID and notify the user via email.
+     *
+     * @param userId ID of the user to delete
+     */
+    public void deleteUserById(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        emailService.sendEmail(user.getEmail(),
+                "Account Deleted",
+                "Your profile has been deleted from the system.");
+
+        userRepository.delete(user);
+    }
+
     public boolean deleteAccount(String email, String password) {
         User user = userRepository.findFirstByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));


### PR DESCRIPTION
## Summary
- allow admins to delete any user by id
- send email notification when a user is removed
- document admin delete notification

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68760fbcc5e083229c9165557bb9b3cc